### PR TITLE
Make the source code discoverable

### DIFF
--- a/business_calendar.gemspec
+++ b/business_calendar.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["rnubel@enova.com"]
   spec.description   = %q{Helper gem for dealing with business days and date adjustment in multiple countries.}
   spec.summary       = %q{Country-aware business-date logic and handling.}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/enova/business_calendar"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
https://rubygems.org/gems/business_calendar doesn't show the _source code_ in the _Links_
See: http://guides.rubygems.org/specification-reference/#homepage